### PR TITLE
Remove redundant package class-registry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ cachetools==5.5.0
 certifi==2022.12.7
 cffi==1.17.1
 charset-normalizer==2.1.1
-class-registry==2.1.2
 colorama==0.4.6
 comm==0.2.2
 contourpy==1.3.0


### PR DESCRIPTION
#https://github.com/votchallenge/toolkit/issues/148

"Make sure to install phx-class-registry, not class-registry. I created the latter at a previous job years ago, and after I left they never touched that project again and stopped responding to my emails — so in the end I had to fork it 🤷"

https://class-registry.readthedocs.io/en/latest/